### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install goodshare.js --save
 
 ```html
 <!-- goodshare.js minify version -->
-<script src="https://cdn.jsdelivr.net/jquery.goodshare.js/4/goodshare.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/goodshare.js@4/goodshare.min.js"></script>
 ```
 
 ## Old way to install


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/goodshare.js.

Feel free to ping me if you have any questions regarding this change.