### PR TITLE
Fix conflict with VK Open API

### DIFF
--- a/src/providers/Vkontakte.js
+++ b/src/providers/Vkontakte.js
@@ -37,7 +37,7 @@ class Vkontakte {
     const count_elements = document.querySelectorAll('[data-counter="vkontakte"]');
     const count_url = 'https://vk.com/share.php?act=count&index=1&url=' + this.url;
     
-    window.VK = { Share: {} };
+    window.VK = Object.assign({}, { Share: {} }, window.VK);
     
     if (count_elements.length > 0) {
       window.VK.Share.count = (counter) => {


### PR DESCRIPTION
goodshare.js breaks custom javascript like
```javascript
VK.Widgets.Comments('vk_comments')
```
and other ["VK Open API"](https://vk.com/dev/openapi) usage.

This PR fixes it.