### PR TITLE
Skype share url update

### DIFF
--- a/src/providers/Skype.js
+++ b/src/providers/Skype.js
@@ -11,9 +11,10 @@
 import { ProviderMixin } from "../utils/ProviderMixin";
 
 export class Skype extends ProviderMixin {
-  constructor(url = document.location.href) {
+  constructor(url = document.location.href, title = document.title) {
     super();
     this.url = encodeURIComponent(url);
+    this.title = encodeURIComponent(title);
     this.createEvents = this.createEvents.bind(this);
   }
 
@@ -21,7 +22,10 @@ export class Skype extends ProviderMixin {
     const url = item.dataset.url
       ? encodeURIComponent(item.dataset.url)
       : this.url;
-    const share_url = `https://web.skype.com/share?${url}`;
+    const title = item.dataset.title
+      ? encodeURIComponent(item.dataset.title)
+      : this.title;
+    const share_url = `https://web.skype.com/share?url=${url}&text=${title}`;
 
     return {
       callback: this.callback,


### PR DESCRIPTION
Skype web sharing URL format had been changed and different query parameters are now expected.

Currently the share URL generated from `https://web.skype.com/share?{url}` template (i.e. https://web.skype.com/share?https%3A%2F%2Fgithub.com%2Fkoddr%2Fgoodshare.js) results in a blank share pop-up with an error:
![error](https://user-images.githubusercontent.com/6200145/196282632-7e8d0f8c-0183-4c77-8a7a-5c004c3bf026.png)

The URL template after change contains required query parameter `url` and an optional query parameter `text` - `https://web.skype.com/share?url={url}&text={title}` (i.e. https://web.skype.com/share?url=https%3A%2F%2Fgithub.com%2Fkoddr%2Fgoodshare.js&text=Demo%20goodshare.js)

![properly shared link](https://user-images.githubusercontent.com/6200145/196284239-f88087d0-ea8e-4149-929a-9bc2bab823ab.png)
