### PR TITLE
Update dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "MIT",
       "devDependencies": {
         "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
-        "@babel/core": "^7.15.0",
-        "@babel/preset-env": "^7.15.0",
-        "@size-limit/preset-app": "^8.0.0",
-        "babel-loader": "^9.0.0",
-        "core-js": "^3.16.0",
-        "rollup": "^2.56.0",
-        "rollup-plugin-babel": "^4.4.0"
+        "@babel/core": "^7.21.5",
+        "@babel/preset-env": "^7.21.5",
+        "@rollup/plugin-babel": "^6.0.3",
+        "@size-limit/preset-app": "^8.2.4",
+        "babel-loader": "^9.1.2",
+        "core-js": "^3.30.1",
+        "rollup": "^3.21.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -66,30 +66,30 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.4.tgz",
-      "integrity": "sha512-/DYyDpeCfaVinT40FPGdkkb+lYSKvsVuMjDAG7jPOWWiM1ibOaB9CXJAlc4d1QpP/U2q2P9jbrSlClKSErd55g==",
+      "version": "7.21.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.21.7.tgz",
+      "integrity": "sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.4.tgz",
-      "integrity": "sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.5.tgz",
+      "integrity": "sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.4",
-        "@babel/helper-compilation-targets": "^7.21.4",
-        "@babel/helper-module-transforms": "^7.21.2",
-        "@babel/helpers": "^7.21.0",
-        "@babel/parser": "^7.21.4",
+        "@babel/generator": "^7.21.5",
+        "@babel/helper-compilation-targets": "^7.21.5",
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helpers": "^7.21.5",
+        "@babel/parser": "^7.21.5",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.4",
-        "@babel/types": "^7.21.4",
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -118,12 +118,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.4.tgz",
-      "integrity": "sha512-NieM3pVIYW2SwGzKoqfPrQsf4xGs9M9AIG3ThppsSRmO+m7eQhmI6amajKMUeIO37wFfsvnvcxQFx6x6iqxDnA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.21.5.tgz",
+      "integrity": "sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.21.4",
+        "@babel/types": "^7.21.5",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -158,12 +158,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.4.tgz",
-      "integrity": "sha512-Fa0tTuOXZ1iL8IeDFUWCzjZcn+sJGd9RZdH9esYVjEejGmzf+FFYQpMi/kZUk2kPy/q1H3/GPw7np8qar/stfg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.21.5.tgz",
+      "integrity": "sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.4",
+        "@babel/compat-data": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
@@ -232,9 +232,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz",
+      "integrity": "sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -302,19 +302,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz",
-      "integrity": "sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz",
+      "integrity": "sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-module-imports": "^7.18.6",
-        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-environment-visitor": "^7.21.5",
+        "@babel/helper-module-imports": "^7.21.4",
+        "@babel/helper-simple-access": "^7.21.5",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.2",
-        "@babel/types": "^7.21.2"
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -333,9 +333,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz",
+      "integrity": "sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -377,12 +377,12 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
-      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz",
+      "integrity": "sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.2"
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -413,9 +413,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -455,14 +455,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.0.tgz",
-      "integrity": "sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.21.5.tgz",
+      "integrity": "sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.21.0",
-        "@babel/types": "^7.21.0"
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,9 +483,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz",
-      "integrity": "sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.21.5.tgz",
+      "integrity": "sha512-J+IxH2IsxV4HbnTrSWgMAQj0UEo61hDA4Ny8h8PCX0MLXiibqHbqIOVneqdocemSBc22VpBKxt4J6FQzy9HarQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -853,6 +853,18 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -968,12 +980,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
-      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.21.5.tgz",
+      "integrity": "sha512-wb1mhwGOCaXHDTcsRYMKF9e5bbMgqwxtqa2Y1ifH96dXJPwbuLX9qHy3clhrxVqgMz7nyNXs8VkxdH8UBcjKqA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1053,12 +1065,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
-      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.21.5.tgz",
+      "integrity": "sha512-TR653Ki3pAwxBxUe8srfF3e4Pe3FTA46uaNHYyQwIoM4oWKSoOZiDNyHJ0oIoDIUPSRQbQG7jzgVBX3FPVne1Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/template": "^7.20.7"
       },
       "engines": {
@@ -1131,12 +1143,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.0.tgz",
-      "integrity": "sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.21.5.tgz",
+      "integrity": "sha512-nYWpjKW/7j/I/mZkGVgHJXh4bA1sfdFnJoOXwJuj4m3Q2EraO/8ZyrkCau9P5tbHQk01RMSt6KYLCsW7730SXQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1209,14 +1221,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.21.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.2.tgz",
-      "integrity": "sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz",
+      "integrity": "sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.21.2",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-simple-access": "^7.20.2"
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-simple-access": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1337,12 +1349,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
-      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.21.5.tgz",
+      "integrity": "sha512-ZoYBKDb6LyMi5yCsByQ5jmXsHAQDDYeexT1Szvlmui+lADvfSecr5Dxd/PkrTC3pAD182Fcju1VQkB4oCp9M+w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "regenerator-transform": "^0.15.1"
       },
       "engines": {
@@ -1444,12 +1456,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
-      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.21.5.tgz",
+      "integrity": "sha512-LYm/gTOwZqsYohlvFUe/8Tujz75LqqVC2w+2qPHLR+WyWHGCZPN1KBpJCJn+4Bk4gOkQy/IXKIge6az5MqwlOg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.9"
+        "@babel/helper-plugin-utils": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1475,14 +1487,14 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.4.tgz",
-      "integrity": "sha512-2W57zHs2yDLm6GD5ZpvNn71lZ0B/iypSdIeq25OurDKji6AdzV07qp4s3n1/x5BqtiGaTrPN3nerlSCaC5qNTw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.21.5.tgz",
+      "integrity": "sha512-wH00QnTTldTbf/IefEVyChtRdw5RJvODT/Vb4Vcxq1AZvtXj6T0YeX0cAcXhI6/BdGuiP3GcNIL4OQbI2DVNxg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.21.4",
-        "@babel/helper-compilation-targets": "^7.21.4",
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/compat-data": "^7.21.5",
+        "@babel/helper-compilation-targets": "^7.21.5",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.20.7",
@@ -1507,6 +1519,7 @@
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1516,22 +1529,22 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.20.7",
+        "@babel/plugin-transform-arrow-functions": "^7.21.5",
         "@babel/plugin-transform-async-to-generator": "^7.20.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
         "@babel/plugin-transform-block-scoping": "^7.21.0",
         "@babel/plugin-transform-classes": "^7.21.0",
-        "@babel/plugin-transform-computed-properties": "^7.20.7",
+        "@babel/plugin-transform-computed-properties": "^7.21.5",
         "@babel/plugin-transform-destructuring": "^7.21.3",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
-        "@babel/plugin-transform-for-of": "^7.21.0",
+        "@babel/plugin-transform-for-of": "^7.21.5",
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
         "@babel/plugin-transform-modules-amd": "^7.20.11",
-        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
         "@babel/plugin-transform-modules-systemjs": "^7.20.11",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.20.5",
@@ -1539,17 +1552,17 @@
         "@babel/plugin-transform-object-super": "^7.18.6",
         "@babel/plugin-transform-parameters": "^7.21.3",
         "@babel/plugin-transform-property-literals": "^7.18.6",
-        "@babel/plugin-transform-regenerator": "^7.20.5",
+        "@babel/plugin-transform-regenerator": "^7.21.5",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
         "@babel/plugin-transform-shorthand-properties": "^7.18.6",
         "@babel/plugin-transform-spread": "^7.20.7",
         "@babel/plugin-transform-sticky-regex": "^7.18.6",
         "@babel/plugin-transform-template-literals": "^7.18.9",
         "@babel/plugin-transform-typeof-symbol": "^7.18.9",
-        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-escapes": "^7.21.5",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.21.4",
+        "@babel/types": "^7.21.5",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -1586,9 +1599,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -1612,19 +1625,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz",
-      "integrity": "sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.5.tgz",
+      "integrity": "sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
-        "@babel/generator": "^7.21.4",
-        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/generator": "^7.21.5",
+        "@babel/helper-environment-visitor": "^7.21.5",
         "@babel/helper-function-name": "^7.21.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.21.4",
-        "@babel/types": "^7.21.4",
+        "@babel/parser": "^7.21.5",
+        "@babel/types": "^7.21.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1633,12 +1646,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
+      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-string-parser": "^7.21.5",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
@@ -1758,6 +1771,60 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@rollup/plugin-babel": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-6.0.3.tgz",
+      "integrity": "sha512-fKImZKppa1A/gX73eg4JGo+8kQr/q1HBQaCGKECZ0v4YBBv3lFqi14+7xyApECzvkLTHCifx+7ntcrvtBIRcpg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.1.9",
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/babel__core": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
+      "integrity": "sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
+    },
     "node_modules/@sitespeed.io/tracium": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz",
@@ -1873,8 +1940,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -3696,7 +3762,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3989,49 +4054,20 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.21.2.tgz",
+      "integrity": "sha512-c4vC+JZ3bbF4Kqq2TtM7zSKtSyMybFOjqmomFax3xpfYaPZDZ4iz8NMIuBRMjnXOcKYozw7bC6vhJjiWD6JpzQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/rollup-plugin-babel": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
-      "integrity": "sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "rollup-pluginutils": "^2.8.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "7 || ^7.0.0-rc.2",
-        "rollup": ">=0.60.0 <3"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
-    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "main": "goodshare.min.js",
   "scripts": {
     "update": "npm outdated && npx npm-check-updates -u && npm install",
-    "build": "rollup --config rollup.config.js --compact",
-    "watch": "rollup --config rollup.config.js --watch --compact",
+    "build": "rollup --config rollup.config.js --compact --bundleConfigAsCjs",
+    "watch": "rollup --config rollup.config.js --watch --compact --bundleConfigAsCjs",
     "size": "npm run build && size-limit"
   },
   "devDependencies": {
     "@ampproject/rollup-plugin-closure-compiler": "^0.27.0",
-    "@babel/core": "^7.15.0",
-    "@babel/preset-env": "^7.15.0",
-    "@size-limit/preset-app": "^8.0.0",
-    "babel-loader": "^9.0.0",
-    "core-js": "^3.16.0",
-    "rollup": "^2.56.0",
-    "rollup-plugin-babel": "^4.4.0"
+    "@babel/core": "^7.21.5",
+    "@babel/preset-env": "^7.21.5",
+    "@rollup/plugin-babel": "^6.0.3",
+    "@size-limit/preset-app": "^8.2.4",
+    "babel-loader": "^9.1.2",
+    "core-js": "^3.30.1",
+    "rollup": "^3.21.2"
   },
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@
  *  Rollup.js Config
  */
 
-import babel from "rollup-plugin-babel";
+import { babel } from "@rollup/plugin-babel";
 import compiler from "@ampproject/rollup-plugin-closure-compiler";
 
 export default [
@@ -15,7 +15,8 @@ export default [
     },
     plugins: [
       babel({
-        exclude: "node_modules/**"
+        exclude: "node_modules/**",
+        babelHelpers: "bundled"
       }),
       compiler({
         compilation_level: "SIMPLE"


### PR DESCRIPTION
Changes:
- migrate from rollup-plugin-babel@^4.4.0[Deprecated] to @rollup/plugin-babel@^6.0.3
- update dev dependencies